### PR TITLE
Fix imports. Recent version of werkzeug removed _compat module.

### DIFF
--- a/feedwerk/atom.py
+++ b/feedwerk/atom.py
@@ -24,7 +24,7 @@
 from datetime import datetime
 from werkzeug.utils import escape
 from werkzeug.wrappers import BaseResponse
-from werkzeug._compat import implements_to_string, string_types
+from feedwerk._compat import implements_to_string, string_types
 
 XHTML_NAMESPACE = 'http://www.w3.org/1999/xhtml'
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with io.open('README.md', 'rt', encoding='utf8') as f:
 
 setup(
     name="feedwerk",
-    version="0.0.1",
+    version="0.0.2",
     url="https://github.com/uniphil/feedwerk",
     project_urls={
         "Documentation": "https://github.com/uniphil/feedwerk",


### PR DESCRIPTION
This allows feedwerk to be used with more recent versions of werkzeug.