### PR TITLE
Fixes for Werkzeug >= 2.1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install pytest flake8 werkzeug${{ matrix.werkzeug-version }}
+      - run: pip install pytest flake8 werkzeug${{ matrix.werkzeug-version }} markupsafe
       - run: python -m pytest
       - run: flake8 --max-line-length=100 *.py tests feedwerk

--- a/feedwerk/atom.py
+++ b/feedwerk/atom.py
@@ -23,7 +23,7 @@
 """
 from datetime import datetime
 from markupsafe import escape
-from werkzeug.wrappers import BaseResponse
+from werkzeug.wrappers import Response
 
 from ._compat import implements_to_string, string_types
 
@@ -216,7 +216,7 @@ class AtomFeed(object):
 
     def get_response(self):
         """Return a response object for the feed."""
-        return BaseResponse(self.to_string(), mimetype='application/atom+xml')
+        return Response(self.to_string(), mimetype='application/atom+xml')
 
     def __call__(self, environ, start_response):
         """Use the class as WSGI response object."""

--- a/feedwerk/atom.py
+++ b/feedwerk/atom.py
@@ -22,7 +22,7 @@
     :license: BSD-3-Clause
 """
 from datetime import datetime
-from werkzeug.utils import escape
+from markupsafe import escape
 from werkzeug.wrappers import BaseResponse
 
 from ._compat import implements_to_string, string_types

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     ],
     packages=find_packages(exclude=('tests*',)),
     include_package_data=True,
-    install_requires=["werkzeug >= 1.0.0"],
+    install_requires=["werkzeug >= 1.0.0", "markupsafe"],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     extras_require={"dev": ["pytest"]},
 )


### PR DESCRIPTION
Picking up from @mar1ad's PR https://github.com/uniphil/feedwerk/pull/2 to also handle `BaseResponse`'s removal from Werkzeug 2.1.0.

- [x] `werkzeug.utils.escape` removed in favour of MarkupSafe
- [x] `werkzeug.wrappers.BaseResponse` removed 

