### PR TITLE
Bump actions versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dist dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
             werkzeug-version: '~=1.0'
     name: Python ${{ matrix.python-version }} / werkzeug ${{ matrix.werkzeug-version }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install pytest werkzeug${{ matrix.werkzeug-version }} markupsafe
@@ -27,7 +27,7 @@ jobs:
       image: python:2.7.18-buster
     name: Python 2.7 / werkzeug ==1.0.0  # werkzeug 2.0 drops python2 entirely
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: pip install pytest werkzeug==1.0.0 markupsafe
       - run: python -m pytest -Werror
 
@@ -35,8 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Lint with flake8
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - run: pip install flake8


### PR DESCRIPTION
Addresses nodejs deprecation warnings from github actions itself.

There is still one pip version warning but 🤷🏼‍♀️ it's coming from within `setup-python` for py3.5 and i don't see an easy way to suppress it, and don't really care that much.

CI tasks still seem to work just fine, hopefully that will also apply to the release workflow, if we ever need another release.